### PR TITLE
[feature/16] 해당 자녀의 진단 내역 조회 API

### DIFF
--- a/src/main/java/com/ureca/child_recommend/child/domain/ChildMbti.java
+++ b/src/main/java/com/ureca/child_recommend/child/domain/ChildMbti.java
@@ -7,7 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.mapping.ToOne;
+
 
 @Entity
 @AllArgsConstructor
@@ -31,15 +31,21 @@ public class ChildMbti extends BaseTimeEntity {
     @JoinColumn(name = "child_id")
     private Child child;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "child_mbti_score_id")
+    private ChildMbtiScore childMbtiScore;
+
     public void updateStatus(ChildMbtiStatus childMbtiStatus) {
         this.status = childMbtiStatus;
     }
 
-    public static ChildMbti enrollToMbti(String result,Child child){
+
+    public static ChildMbti enrollToMbti(String result,Child child,ChildMbtiScore newChildMbtiScore){
         return ChildMbti.builder()
                 .mbtiResult(result)
                 .status(ChildMbtiStatus.ACTIVE)
                 .child(child)
+                .childMbtiScore(newChildMbtiScore)
                 .build();
     }
 

--- a/src/main/java/com/ureca/child_recommend/child/domain/ChildMbtiScore.java
+++ b/src/main/java/com/ureca/child_recommend/child/domain/ChildMbtiScore.java
@@ -1,8 +1,6 @@
 package com.ureca.child_recommend.child.domain;
 
-
 import com.ureca.child_recommend.child.domain.Enum.ChildMbtiScoreStatus;
-import com.ureca.child_recommend.child.domain.Enum.ChildMbtiStatus;
 import com.ureca.child_recommend.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/ureca/child_recommend/child/domain/Enum/ChildMbtiStatus.java
+++ b/src/main/java/com/ureca/child_recommend/child/domain/Enum/ChildMbtiStatus.java
@@ -1,5 +1,5 @@
 package com.ureca.child_recommend.child.domain.Enum;
 
 public enum ChildMbtiStatus {
-    ACTIVE, NONACTIVE
+    ACTIVE,NONACTIVE,DELETE
 }

--- a/src/main/java/com/ureca/child_recommend/child/infrastructure/ChildMbtiRepository.java
+++ b/src/main/java/com/ureca/child_recommend/child/infrastructure/ChildMbtiRepository.java
@@ -1,11 +1,22 @@
 package com.ureca.child_recommend.child.infrastructure;
 
 import com.ureca.child_recommend.child.domain.ChildMbti;
+import com.ureca.child_recommend.child.domain.ChildMbtiScore;
 import com.ureca.child_recommend.child.domain.Enum.ChildMbtiStatus;
+import feign.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChildMbtiRepository extends JpaRepository<ChildMbti,Long> {
     Optional<ChildMbti> findByChildIdAndStatus(Long id, ChildMbtiStatus status);
+
+    Optional<ChildMbti> findByChildMbtiScore(ChildMbtiScore childMbtiScore);
+
+    @Query("SELECT c.mbtiResult FROM ChildMbti c WHERE c.childMbtiScore = :childMbtiScore AND c.status IN ('ACTIVE', 'NONACTIVE')")
+    String findMbtiResultByChildMbtiScore(@Param("childMbtiScore") ChildMbtiScore childMbtiScore);
+
+
 }

--- a/src/main/java/com/ureca/child_recommend/child/infrastructure/ChildMbtiScoreRepository.java
+++ b/src/main/java/com/ureca/child_recommend/child/infrastructure/ChildMbtiScoreRepository.java
@@ -22,4 +22,6 @@ public interface ChildMbtiScoreRepository extends JpaRepository<ChildMbtiScore, 
     void deleteByUpdateAtAndStatus(LocalDateTime thresholdDateTime, ChildMbtiScoreStatus childMbtiScoreStatus);
 
     List<ChildMbtiScore> findByAssessmentDateAndStatus(LocalDate yesterday, ChildMbtiScoreStatus childMbtiScoreStatus);
+
+    List<ChildMbtiScore> findByChildIdAndStatusIn(Long childId,List<ChildMbtiScoreStatus> status);
 }

--- a/src/main/java/com/ureca/child_recommend/child/presentation/MbtiController.java
+++ b/src/main/java/com/ureca/child_recommend/child/presentation/MbtiController.java
@@ -1,11 +1,14 @@
 package com.ureca.child_recommend.child.presentation;
 
 import com.ureca.child_recommend.child.application.MbtiService;
+import com.ureca.child_recommend.child.presentation.dto.ChildDto;
 import com.ureca.child_recommend.child.presentation.dto.MbtiDto;
 import com.ureca.child_recommend.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,6 +32,16 @@ public class MbtiController {
         return SuccessResponse.success(childMbtiScore_id);
     }
 
+    /**
+     * 24.10.29 작성자 : 정주현
+     * 자녀의 진단 내역 조회
+     */
+    @GetMapping("/assessment/{child_id}")
+    public SuccessResponse<List<MbtiDto.Response.assessmentMbtiResultDto>> getAssessmentMbtiResults(@AuthenticationPrincipal Long userId,@PathVariable("child_id") Long childId){
+        List<MbtiDto.Response.assessmentMbtiResultDto> response =  mbtiService.getAssessmentMbtiResults(userId,childId);
+        return SuccessResponse.success(response);
+
+    }
 }
 
 

--- a/src/main/java/com/ureca/child_recommend/child/presentation/dto/MbtiDto.java
+++ b/src/main/java/com/ureca/child_recommend/child/presentation/dto/MbtiDto.java
@@ -1,10 +1,13 @@
 package com.ureca.child_recommend.child.presentation.dto;
 
+import com.ureca.child_recommend.child.domain.ChildMbtiScore;
+import com.ureca.child_recommend.child.domain.Enum.ChildMbtiScoreStatus;
 import lombok.Builder;
 import lombok.Getter;
 
-public class MbtiDto {
+import java.time.LocalDate;
 
+public class MbtiDto {
     public static class Response{
         @Builder
         @Getter
@@ -17,6 +20,32 @@ public class MbtiDto {
                         .build();
             }
         }
+
+        @Builder
+        @Getter
+        public static class assessmentMbtiResultDto{
+            private Long childMbtiScoreId;
+            private LocalDate assessmentDate;
+            private int eiScore;
+            private int jpScore;
+            private int snScore;
+            private int tfScore;
+            private String mbtiResult;
+            private ChildMbtiScoreStatus status;
+            public static assessmentMbtiResultDto of(ChildMbtiScore childMbtiScore, String mbtiResult){
+                return assessmentMbtiResultDto.builder()
+                        .childMbtiScoreId(childMbtiScore.getId())
+                        .assessmentDate(childMbtiScore.getAssessmentDate())
+                        .eiScore(childMbtiScore.getEiScore())
+                        .jpScore(childMbtiScore.getJpScore())
+                        .snScore(childMbtiScore.getSnScore())
+                        .tfScore(childMbtiScore.getTfScore())
+                        .mbtiResult(mbtiResult)
+                        .status(childMbtiScore.getStatus())
+                        .build();
+            }
+        }
+
 
     }
     public static class Request{


### PR DESCRIPTION


> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    -x

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

   - childMbti에 일대일연결로 childMbtiScore추가 : 
        - 삭제시 -> ChildMbti/Score DELETE 상태 변경
        - 재진단시 ->  ChildMbti/Score NONACTIVE 상태 변경
        - 피드백시 -> 오늘 날짜의 ACTIVE된 childMbtiScore 값이 update, 결과가 바뀌면 ChildMbti의 값이 update 되므로, 1:1 관계이므로 OnetoOne으로 변경

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    -  위 내용과 같으며, 자정에 30일이 지났을때 ,ChildMbtiScore가 삭제되는 걸로 되어있는데 ChildMbti 삭제되게끔 수정해야한다. 같은 팀원이 한 부분이라

> ## 💾&nbsp;&nbsp;DB 업데이트

    - [데이터베이스 변경사항 여부] : Yes

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
