### PR TITLE
[refactor/23] RedisUtil 위한 리팩토링

### DIFF
--- a/src/main/java/com/ureca/child_recommend/config/redis/util/RedisUtil.java
+++ b/src/main/java/com/ureca/child_recommend/config/redis/util/RedisUtil.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -33,6 +34,11 @@ public class RedisUtil {
     // 새 메서드 추가: Redis 리스트에 데이터를 삽입하는 메서드
     public void pushToList(String key, String value) {
         redisTemplate.opsForList().leftPush(key, value);
+    }
+
+    // Redis 리스트에서 데이터를 범위로 가져오기
+    public List<Object> getListRange(String key, long start, long end) {
+        return redisTemplate.opsForList().range(key, start, end);
     }
 
 }

--- a/src/main/java/com/ureca/child_recommend/notice/presentation/SseController.java
+++ b/src/main/java/com/ureca/child_recommend/notice/presentation/SseController.java
@@ -1,5 +1,6 @@
 package com.ureca.child_recommend.notice.presentation;
 
+import com.ureca.child_recommend.config.redis.util.RedisUtil;
 import com.ureca.child_recommend.notice.application.SseEmitterManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -31,17 +32,16 @@ public class SseController {
 
 }*/
 
-private final SseEmitterManager sseEmitterManager;
-
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final SseEmitterManager sseEmitterManager;
+    private final RedisUtil redisUtil;
 
     private static final String NOTIFICATION_KEY = "notifications";
 
 
 @Autowired
-public SseController(SseEmitterManager sseEmitterManager, RedisTemplate<String, Object> redisTemplate) {
+public SseController(SseEmitterManager sseEmitterManager, RedisUtil redisUtil) {
     this.sseEmitterManager = sseEmitterManager;
-    this.redisTemplate = redisTemplate;
+    this.redisUtil = redisUtil;
 }
 
 @GetMapping("/newbook")
@@ -55,8 +55,8 @@ public void sendSseEvent(String notification){
 
     @GetMapping("/previous")
     public List<Object> getPreviousNotifications() {
-        // Redis에 저장된 모든 이전 알림을 가져옵니다.
-        return redisTemplate.opsForList().range(NOTIFICATION_KEY, 0, -1);
+        // RedisUtil을 통해 Redis에 저장된 모든 이전 알림을 가져옵니다.
+        return redisUtil.getListRange(NOTIFICATION_KEY, 0, -1);
     }
 
 }


### PR DESCRIPTION
RedisTemplate을 사용해 redis에 직접 의존하지 않고 RedisUtil을 사용하게 관리

> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    -

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - RedisTemplate을 이용하지 않고 RedisUtil에서 관리한다.

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 

> ## 💾&nbsp;&nbsp;DB 업데이트

    - [데이터베이스 변경사항 여부] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
