### PR TITLE
[fix/31] 재 진단시 벡터디비에 값 들어가는 것 오류 수정

### DIFF
--- a/src/main/java/com/ureca/child_recommend/child/application/MbtiService.java
+++ b/src/main/java/com/ureca/child_recommend/child/application/MbtiService.java
@@ -63,6 +63,12 @@ public class MbtiService {
         // ChildMbti 저장
         childMbtiRepository.save(ChildMbti.enrollToMbti(result, child,newChildMbtiScore));
 
+        // ChildVector 삭제 후 즉시 반영
+        childVectorRepository.findByChild(child).ifPresent(childVector -> {
+            childVectorRepository.delete(childVector);
+            childVectorRepository.flush();
+        });
+
         inputEmbedding(child,newChildMbtiScore);
 
         return MbtiDto.Response.assessmentMbtiDto.of(result);

--- a/src/main/java/com/ureca/child_recommend/child/domain/ChildVector.java
+++ b/src/main/java/com/ureca/child_recommend/child/domain/ChildVector.java
@@ -29,14 +29,14 @@ public class ChildVector extends BaseTimeEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "child_id")
-    private Child childId;
+    private Child child;
 
 
 
     public static ChildVector createChildVector(float[] childEmbedding,Child child){
         return ChildVector.builder()
                 .embedding(childEmbedding)
-                .childId(child)
+                .child(child)
                 .build();
 
     }

--- a/src/main/java/com/ureca/child_recommend/child/infrastructure/ChildVectorRepository.java
+++ b/src/main/java/com/ureca/child_recommend/child/infrastructure/ChildVectorRepository.java
@@ -1,10 +1,12 @@
 package com.ureca.child_recommend.child.infrastructure;
 
+import com.ureca.child_recommend.child.domain.Child;
 import com.ureca.child_recommend.child.domain.ChildVector;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChildVectorRepository extends JpaRepository<ChildVector,Long> {
     @Query(nativeQuery = true,
@@ -24,6 +26,8 @@ public interface ChildVectorRepository extends JpaRepository<ChildVector,Long> {
                     "ORDER BY cv2.embedding <-> cv1.embedding " +
                     "LIMIT 15")
     List<Long> findSimilarChildId(Long childId);
+
+    Optional<ChildVector> findByChild(Child child);
 }
 
 


### PR DESCRIPTION

> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - x

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - ChildVector 엔티티 내, childId가 1:1 관계이므로, 중복이 일어나면 안됨.
    - MbtiService: saveMbtiResult() 메소드 내, ChildVector에 childId가에 해당 하는 값 있을 시, delete한 후 flush()로 바로 반영하게 끔 함.

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    -  x

> ## 💾&nbsp;&nbsp;DB 업데이트

    - [데이터베이스 변경사항 여부] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
