### PR TITLE
[feature/33] 실시간(하루) 좋아요 많이 받은 도서 추천

### DIFF
--- a/src/main/java/com/ureca/child_recommend/contents/application/ContentsService.java
+++ b/src/main/java/com/ureca/child_recommend/contents/application/ContentsService.java
@@ -36,6 +36,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static com.ureca.child_recommend.relation.application.FeedBackSchedulerService.TODAY_LIKE_CONTENTS;
 import static com.ureca.child_recommend.relation.application.FeedBackService.CHILD_LIKED_BOOK_SIMILARITY_RECOMMENDATIONS;
 
 @Service
@@ -348,5 +349,10 @@ public class ContentsService {
         return similarBookDtoList;
 
 
+    }
+
+    public List<ContentsRecommendDto.Response.SimilarBookDto> getMostLikedBooksToday() {
+
+        return redisUtil.getBooks(TODAY_LIKE_CONTENTS);
     }
 }

--- a/src/main/java/com/ureca/child_recommend/contents/presentation/ContentsController.java
+++ b/src/main/java/com/ureca/child_recommend/contents/presentation/ContentsController.java
@@ -77,6 +77,16 @@ public class ContentsController {
 
     }
 
+    /**
+     * 24.11.02 작성자 : 정주현
+     * 오늘 하루 좋아요 가장 많이 받은 도서 조회
+     */
+    @GetMapping("/most-liked-today")
+    public SuccessResponse<List<ContentsRecommendDto.Response.SimilarBookDto>> getMostLikedBooksToday(){
+        List<ContentsRecommendDto.Response.SimilarBookDto> response = contentsService.getMostLikedBooksToday();
+        return SuccessResponse.success(response);
+    }
+
     //    /**
 //     * 24.10.24 작성자 : 정주현
 //     * 도서 임베딩 값 삽입

--- a/src/main/java/com/ureca/child_recommend/relation/application/FeedBackService.java
+++ b/src/main/java/com/ureca/child_recommend/relation/application/FeedBackService.java
@@ -42,7 +42,7 @@ public class FeedBackService {
     private final RedisUtil redisUtil;
 
     public final static String CHILD_LIKED_BOOK_SIMILARITY_RECOMMENDATIONS = "Child_Like_RecommendBook_ChildId : ";
-    private static final String REDIS_KEY = "content:likes";
+    public static final String REDIS_KEY = "content:likes";
 
     public List<String> getLikedContents(Long childId) {
         // 좋아요한 피드백 목록을 가져옴


### PR DESCRIPTION

> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    -

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 매일 자정에 오늘 하루 좋아요 받은 도서의 score delete(스케줄러 처리)
    - 매일 매시 58분에 당시 좋아요 가장 많은 도서 상위 10개 뽑아서 디비에서 도서 값 추출 후, 레디스에 적재
    - 실시간(하루) 좋아요 많이 받은 도서 조회시, 레디스에서 조회하므로, 디비 접근x 성능 최적화

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    -  만약 자정에 오늘 하루 좋아요 받은 도서의 score delete 한 뒤, 58분동안, 좋아요 그 누구도 좋아요 한 도서가 없다면, 당시 좋아요 가장 많은 도서가 없다. 이는 고민해볼 문제이다.
    -  레디스에서 바로 조회해오기만 했는데, 레디스가 다운되거나, 값이 없을 시 디비에서 찾아와야하는데 오늘 하루 좋아요 많이 받은 값은 레디스에 있었어서 찾아오려면 피드백 테이블에서 createAt가 오늘인 것을 다 select 해와야한다. 이는 더 생각할 부분

> ## 💾&nbsp;&nbsp;DB 업데이트

    - [데이터베이스 변경사항 여부] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
